### PR TITLE
Add support for Tenancy v4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.0]
+        php: [8.2]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Activate Pest Composer Plugin
         run: composer config --no-plugins allow-plugins.pestphp/pest-plugin true
 
+      - name: Composer Authentication
+        run: composer config github-oauth.github.com ${{ secrets.PRIVATE_PACKAGE_ACCESS_TOKEN }}
+
       - name: Install dependencies
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.2]
+        php: [8.4]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-# Provision S3 Buckets for each tenant.
-![Vidwan/Tenant-Buckets](https://banners.beyondco.de/Tenant%20Buckets.png?theme=dark&packageManager=composer+require&packageName=vidwan%2Ftenant-buckets&pattern=circuitBoard&style=style_1&description=Provision+S3+Buckets+for+tenants.&md=1&showWatermark=0&fontSize=100px&images=collection)
+<p align="center"><a href="https://fourdotsix.com" target="_blank"><img src="https://cdn.fourdotsix.com/images/4.6/logo/4.6-bimi.svg" width="200" alt="fourdotsix.com Logo"></a><br><strong>four●six</strong> // tenant-buckets</p>
+
+# Provision S3 Buckets for each tenant
+
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/vidwan/tenant-buckets.svg?style=flat-square)](https://packagist.org/packages/vidwan/tenant-buckets)
 [![Tests](https://github.com/vidwanco/tenant-buckets/actions/workflows/run-tests.yml/badge.svg?branch=main)](https://github.com/vidwanco/tenant-buckets/actions/workflows/run-tests.yml)
 [![Total Downloads](https://img.shields.io/packagist/dt/vidwan/tenant-buckets.svg?style=flat-square)](https://packagist.org/packages/vidwan/tenant-buckets)
 
-Automatically Provision AWS S3 Buckets for each tenant. It's an Extention for [stancl/tenancy](https://github.com/stancl/tenancy). For more details refer to [TenancyForLaravel](https://tenancyforlaravel.com/).
+Automatically Provision AWS S3 Buckets for each tenant. It's an Extension for [stancl/tenancy](https://github.com/stancl/tenancy). For more details refer to [TenancyForLaravel](https://tenancyforlaravel.com/).
 
 ## Tenancy V4.x
 
@@ -24,17 +26,8 @@ composer require vidwan/tenant-buckets:^4.0.0-rc
 
 ## Concept
 
-The concept is simple, to automatically provison a new AWS S3 bucket for tenant on registration and update the same on the central database's tenant table & data coloumn under `tenant_bucket`.
+The concept is simple, to automatically provision a new AWS S3 bucket for tenant on registration and update the same on the central database's tenant table & data column under `tenant_bucket`.
 Then using a bootstrapper updating the bucket in config `filesystems.disks.s3.bucket` during runtime when in Tenant's context and then reverting it back on central context.
-
-### Roadmap
-
-- [x] Automatic Bucket Creation
-- [x] Selecting the created bucket during Tenancy Bootstrapping.
-- [x] Deletion of Bucket when the Tenant is deleted.
-- [ ] Testing with Amazon S3 service.
-
-> **Note:** I have still not tested this package under ***production*** environment or with a real AWS S3 Bucket. I have only tested it under ***development*** environment using [MinIO](https://min.io/). I will update this after testing it on AWS S3 Bucket with an additional section on AWS IAM Policy Setup for creating the buckets using `aws-sdk-php`. Untill then, if you have tested, a PR is welcome.
 
 ## Installation
 
@@ -171,3 +164,7 @@ Please review [our security policy](../../security/policy) on how to report secu
 ## License
 
 The MIT License (MIT). Please see [License File](LICENSE.md) for more information.
+
+## <br><br>
+
+<p align="center">From the folks at <a href="https://fourdotsix.com" target="_blank">Four Dot Six (4.6)</a></p>

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,14 @@
             "role": "Developer"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/tenancy-for-laravel/v4"
+        }
+    ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.2",
         "aws/aws-sdk-php": "~3.0",
         "stancl/tenancy": "dev-master"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.0",
         "aws/aws-sdk-php": "~3.0",
-        "stancl/tenancy": "^3.4"
+        "stancl/tenancy": "dev-master"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -7,12 +7,12 @@
         "Tenancy For Laravel",
         "tenancyforlaravel"
     ],
-    "homepage": "https://github.com/vidwan-co/tenant-buckets",
+    "homepage": "https://github.com/fourdotsix/tenant-buckets",
     "license": "MIT",
     "authors": [
         {
-            "name": "Shashwat Mishra",
-            "email": "shashwat@vidwan.co",
+            "name": "Hash",
+            "email": "11258035+secrethash@users.noreply.github.com",
             "role": "Developer"
         }
     ],

--- a/src/Bootstrappers/TenantBucketBootstrapper.php
+++ b/src/Bootstrappers/TenantBucketBootstrapper.php
@@ -26,7 +26,7 @@ class TenantBucketBootstrapper implements TenancyBootstrapper
         $this->orignalBucket = $this->app['config']['filesystems.disks.s3.bucket'];
     }
 
-    public function bootstrap(Tenant $tenant)
+    public function bootstrap(Tenant $tenant): void
     {
         // Select Bucket Name
         $bucket = 'tenant'.$tenant->getTenantKey();
@@ -34,7 +34,7 @@ class TenantBucketBootstrapper implements TenancyBootstrapper
         $this->app['config']['filesystems.disks.s3.bucket'] = $bucket;
     }
 
-    public function revert()
+    public function revert(): void
     {
         //
         $this->app['config']['filesystems.disks.s3.bucket'] = $this->orignalBucket;

--- a/src/Bucket.php
+++ b/src/Bucket.php
@@ -177,5 +177,4 @@ class Bucket
     {
         return str(preg_replace('/[^a-zA-Z0-9]/', '', $name))->lower()->toString();
     }
-
 }

--- a/src/Bucket.php
+++ b/src/Bucket.php
@@ -3,7 +3,6 @@
 namespace Vidwan\TenantBuckets;
 
 use Aws\Credentials\Credentials;
-
 use Aws\Exception\AwsException;
 use Aws\S3\S3Client;
 use Illuminate\Support\Facades\Log;
@@ -15,7 +14,6 @@ use Vidwan\TenantBuckets\Events\DeletingBucket;
 
 class Bucket
 {
-
     /**
      * @var \AWS\Credentials\Credentials Credentials Object
     */
@@ -160,8 +158,9 @@ class Bucket
             ]);
         } catch (AwsException $e) {
             $this->e = $e;
-            if (config('tenant-buckets.errors.throw', true))
+            if (config('tenant-buckets.errors.throw', true)) {
                 throw $e;
+            }
             Log::error($this->getErrorMessage());
         }
 

--- a/src/Bucket.php
+++ b/src/Bucket.php
@@ -6,7 +6,7 @@ use Aws\Credentials\Credentials;
 use Aws\Exception\AwsException;
 use Aws\S3\S3Client;
 use Illuminate\Support\Facades\Log;
-use Stancl\Tenancy\Contracts\TenantWithDatabase;
+use Stancl\Tenancy\Contracts\Tenant;
 use Vidwan\TenantBuckets\Events\CreatedBucket;
 use Vidwan\TenantBuckets\Events\CreatingBucket;
 use Vidwan\TenantBuckets\Events\DeletedBucket;
@@ -47,7 +47,7 @@ class Bucket
     protected AwsException|null $e;
 
     public function __construct(
-        protected TenantWithDatabase $tenant
+        protected Tenant $tenant
     ) {
         $this->setupCredentials();
     }
@@ -93,7 +93,7 @@ class Bucket
      * Create a New Bucket
      *
      * @param string $name Name of the S3 Bucket
-     * @param Aws\Credentials\Credentials $credentials AWS Credentials Object
+     * @param \Aws\Credentials\Credentials $credentials AWS Credentials Object
      * @access public
      * @return self $this
      */
@@ -134,7 +134,7 @@ class Bucket
      * Create a New Bucket
      *
      * @param string $name Name of the S3 Bucket
-     * @param Aws\Credentials\Credentials $credentials AWS Credentials Object
+     * @param \Aws\Credentials\Credentials $credentials AWS Credentials Object
      * @access public
      * @return self $this
      */
@@ -180,7 +180,7 @@ class Bucket
     }
 
     /**
-     * Get Error Messsge
+     * Get Error Message
      *
      * @return string|null
      */
@@ -198,6 +198,6 @@ class Bucket
      */
     public function getErrorBag(): AwsException|null
     {
-        return $this->e ? $this->e : null;
+        return $this->e ?: null;
     }
 }

--- a/src/Bucket.php
+++ b/src/Bucket.php
@@ -200,8 +200,10 @@ class Bucket
                 'error_message' => $this->e?->getAwsErrorMessage(),
                 'response' => $this->e?->getResponse(),
             ];
+
             return "[tenant-buckets] Error: (Tenant ID: {$this->tenant->id}) {$this->e->getAwsErrorMessage()} ". json_encode($data);
         }
+
         return null;
     }
 

--- a/src/Bucket.php
+++ b/src/Bucket.php
@@ -111,11 +111,11 @@ class Bucket
 
         try {
             $client->createBucket([
-                'Bucket' => $name,
+                'Bucket' => $this->bucketName,
             ]);
 
             // Update Tenant
-            $this->tenant->tenant_bucket = $name;
+            $this->tenant->tenant_bucket = $this->bucketName;
             $this->tenant->save();
         } catch (AwsException $e) {
             $this->e = $e;
@@ -155,7 +155,7 @@ class Bucket
             ]);
         } catch (AwsException $e) {
             $this->e = $e;
-            throw_if(config('app.debug'), $e);
+            throw_if(config('app.debug', false), $e);
             Log::critical($this->getErrorMessage());
         }
 

--- a/src/Exceptions/BaseException.php
+++ b/src/Exceptions/BaseException.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Vidwan\TenantBuckets\Exceptions;
+
+use Aws\Exception\AwsException;
+use Exception;
+use Throwable;
+
+abstract class BaseException extends Exception
+{
+
+    protected array $data;
+
+    protected AwsException $awsException;
+
+    public function __construct(string $message = "", int $code = 0, Throwable|null $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getAwsException(): AwsException
+    {
+        return $this->awsException;
+    }
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+}

--- a/src/Exceptions/BaseException.php
+++ b/src/Exceptions/BaseException.php
@@ -8,7 +8,6 @@ use Throwable;
 
 abstract class BaseException extends Exception
 {
-
     protected array $data;
 
     protected AwsException $awsException;

--- a/src/Exceptions/CreateBucketException.php
+++ b/src/Exceptions/CreateBucketException.php
@@ -7,15 +7,13 @@ use Stancl\Tenancy\Contracts\Tenant;
 
 class CreateBucketException extends BaseException
 {
-
     public function __construct(
         protected Tenant $tenant,
         protected string $bucketName,
         protected AwsException $awsException
-    )
-    {
+    ) {
         $message = "[tenant-buckets] Error: (Tenant ID: {$tenant->id}) {$awsException->getAwsErrorMessage()}";
-        parent::__construct($message,$awsException->getCode(), $awsException);
+        parent::__construct($message, $awsException->getCode(), $awsException);
 
         $this->setData();
     }
@@ -30,7 +28,7 @@ class CreateBucketException extends BaseException
             'error_message' => $this->awsException->getAwsErrorMessage(),
             'response' => $this->awsException->getResponse(),
         ];
+
         return $this;
     }
-
 }

--- a/src/Exceptions/CreateBucketException.php
+++ b/src/Exceptions/CreateBucketException.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Vidwan\TenantBuckets\Exceptions;
+
+use Aws\Exception\AwsException;
+use Stancl\Tenancy\Contracts\Tenant;
+
+class CreateBucketException extends BaseException
+{
+
+    public function __construct(
+        protected Tenant $tenant,
+        protected string $bucketName,
+        protected AwsException $awsException
+    )
+    {
+        $message = "[tenant-buckets] Error: (Tenant ID: {$tenant->id}) {$awsException->getAwsErrorMessage()}";
+        parent::__construct($message,$awsException->getCode(), $awsException);
+
+        $this->setData();
+    }
+
+    private function setData(): static
+    {
+        $this->data = [
+            'tenant' => $this->tenant->id,
+            'bucket' => $this->bucketName,
+            'error_code' => $this->awsException->getAwsErrorCode(),
+            'error_type' => $this->awsException->getAwsErrorType(),
+            'error_message' => $this->awsException->getAwsErrorMessage(),
+            'response' => $this->awsException->getResponse(),
+        ];
+        return $this;
+    }
+
+}

--- a/src/Exceptions/DeleteBucketException.php
+++ b/src/Exceptions/DeleteBucketException.php
@@ -7,15 +7,13 @@ use Stancl\Tenancy\Contracts\Tenant;
 
 class DeleteBucketException extends BaseException
 {
-
     public function __construct(
         protected Tenant $tenant,
         protected string $bucketName,
         protected AwsException $awsException
-    )
-    {
+    ) {
         $message = "[tenant-buckets] Error: (Tenant ID: {$tenant->id}) {$awsException->getAwsErrorMessage()}";
-        parent::__construct($message,$awsException->getCode(), $awsException);
+        parent::__construct($message, $awsException->getCode(), $awsException);
 
         $this->setData();
     }
@@ -30,7 +28,7 @@ class DeleteBucketException extends BaseException
             'error_message' => $this->awsException->getAwsErrorMessage(),
             'response' => $this->awsException->getResponse(),
         ];
+
         return $this;
     }
-
 }

--- a/src/Exceptions/DeleteBucketException.php
+++ b/src/Exceptions/DeleteBucketException.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Vidwan\TenantBuckets\Exceptions;
+
+use Aws\Exception\AwsException;
+use Stancl\Tenancy\Contracts\Tenant;
+
+class DeleteBucketException extends BaseException
+{
+
+    public function __construct(
+        protected Tenant $tenant,
+        protected string $bucketName,
+        protected AwsException $awsException
+    )
+    {
+        $message = "[tenant-buckets] Error: (Tenant ID: {$tenant->id}) {$awsException->getAwsErrorMessage()}";
+        parent::__construct($message,$awsException->getCode(), $awsException);
+
+        $this->setData();
+    }
+
+    private function setData(): static
+    {
+        $this->data = [
+            'tenant' => $this->tenant->id,
+            'bucket' => $this->bucketName,
+            'error_code' => $this->awsException->getAwsErrorCode(),
+            'error_type' => $this->awsException->getAwsErrorType(),
+            'error_message' => $this->awsException->getAwsErrorMessage(),
+            'response' => $this->awsException->getResponse(),
+        ];
+        return $this;
+    }
+
+}

--- a/src/Jobs/CreateTenantBucket.php
+++ b/src/Jobs/CreateTenantBucket.php
@@ -18,12 +18,6 @@ class CreateTenantBucket implements ShouldQueue
     use SerializesModels;
 
     /**
-     * Current Tenant
-     * @access protected
-     */
-    protected $tenant;
-
-    /**
      * The number of times the job may be attempted.
      *
      * @var int
@@ -42,11 +36,7 @@ class CreateTenantBucket implements ShouldQueue
      *
      * @return void
      */
-    public function __construct(Tenant $tenant)
-    {
-        //
-        $this->tenant = $tenant;
-    }
+    public function __construct(protected Tenant $tenant) {}
 
     /**
      * Execute the job.
@@ -55,11 +45,7 @@ class CreateTenantBucket implements ShouldQueue
      */
     public function handle()
     {
-        $bucket = new Bucket($this->tenant);
-        $create = $bucket->createTenantBucket();
-
-        // $this->tenant->tenant_bucket = $create->getBucketName();
-        // $this->tenant->save();
+        (new Bucket($this->tenant))->createTenantBucket();
     }
 
     /**

--- a/src/Jobs/CreateTenantBucket.php
+++ b/src/Jobs/CreateTenantBucket.php
@@ -7,7 +7,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Stancl\Tenancy\Contracts\TenantWithDatabase;
+use Stancl\Tenancy\Contracts\Tenant;
 use Vidwan\TenantBuckets\Bucket;
 
 class CreateTenantBucket implements ShouldQueue
@@ -42,7 +42,7 @@ class CreateTenantBucket implements ShouldQueue
      *
      * @return void
      */
-    public function __construct(TenantWithDatabase $tenant)
+    public function __construct(Tenant $tenant)
     {
         //
         $this->tenant = $tenant;

--- a/src/Jobs/CreateTenantBucket.php
+++ b/src/Jobs/CreateTenantBucket.php
@@ -36,7 +36,9 @@ class CreateTenantBucket implements ShouldQueue
      *
      * @return void
      */
-    public function __construct(protected Tenant $tenant) {}
+    public function __construct(protected Tenant $tenant)
+    {
+    }
 
     /**
      * Execute the job.

--- a/src/Jobs/DeleteTenantBucket.php
+++ b/src/Jobs/DeleteTenantBucket.php
@@ -7,7 +7,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Stancl\Tenancy\Contracts\TenantWithDatabase;
+use Stancl\Tenancy\Contracts\Tenant;
 use Vidwan\TenantBuckets\Bucket;
 
 class DeleteTenantBucket implements ShouldQueue
@@ -42,7 +42,7 @@ class DeleteTenantBucket implements ShouldQueue
      *
      * @return void
      */
-    public function __construct(TenantWithDatabase $tenant)
+    public function __construct(Tenant $tenant)
     {
         //
         $this->tenant = $tenant;

--- a/src/Jobs/DeleteTenantBucket.php
+++ b/src/Jobs/DeleteTenantBucket.php
@@ -36,7 +36,9 @@ class DeleteTenantBucket implements ShouldQueue
      *
      * @return void
      */
-    public function __construct(protected Tenant $tenant) {}
+    public function __construct(protected Tenant $tenant)
+    {
+    }
 
     /**
      * Execute the job.

--- a/src/Jobs/DeleteTenantBucket.php
+++ b/src/Jobs/DeleteTenantBucket.php
@@ -18,12 +18,6 @@ class DeleteTenantBucket implements ShouldQueue
     use SerializesModels;
 
     /**
-     * Current Tenant
-     * @access protected
-     */
-    protected $tenant;
-
-    /**
      * The number of times the job may be attempted.
      *
      * @var int
@@ -42,11 +36,7 @@ class DeleteTenantBucket implements ShouldQueue
      *
      * @return void
      */
-    public function __construct(Tenant $tenant)
-    {
-        //
-        $this->tenant = $tenant;
-    }
+    public function __construct(protected Tenant $tenant) {}
 
     /**
      * Execute the job.
@@ -55,8 +45,7 @@ class DeleteTenantBucket implements ShouldQueue
      */
     public function handle()
     {
-        $bucket = new Bucket($this->tenant);
-        $delete = $bucket->deleteTenantBucket();
+        (new Bucket($this->tenant))->deleteTenantBucket();
     }
 
     /**


### PR DESCRIPTION
This PR introduces:
- Tenancy v4.x Compatibility
- Minimum PHP version changed to `^8.2`
- Refactor code
- Fix Error reporting
- Fix Bucket Naming
- Always throws exception on error for `Bucket::createBucket()` & `Bucket::deleteBucket()`